### PR TITLE
Fixed Options.php

### DIFF
--- a/src/Model/Options.php
+++ b/src/Model/Options.php
@@ -74,14 +74,12 @@ class Options extends Model
                 $writer->value($from);
                 $writer->endProperty();
 
-                $writer->startArray('old_codes');
                 foreach($groups as $group)
                 {
                     $writer->startObject('group_code');
                     $writer->value($group);
                     $writer->endObject();
                 }
-                $writer->endArray();
                 $writer->endObject();
             }
         }


### PR DESCRIPTION
The <old_codes> tag is invalid according to advisor_schema.xsd and is not used in the Options Import.